### PR TITLE
Implement __str__ on model objects

### DIFF
--- a/zebra/models.py
+++ b/zebra/models.py
@@ -13,6 +13,9 @@ class StripeCustomer(models.Model, mixins.StripeMixin, mixins.StripeCustomerMixi
     def __unicode__(self):
         return u"%s" % self.stripe_customer_id
 
+    def __str__(self):
+        return self.__unicode__()
+
 
 class StripePlan(models.Model, mixins.StripeMixin, mixins.StripePlanMixin):
     stripe_plan_id = models.CharField(max_length=50, blank=True, null=True)
@@ -22,6 +25,9 @@ class StripePlan(models.Model, mixins.StripeMixin, mixins.StripePlanMixin):
 
     def __unicode__(self):
         return u"%s" % self.stripe_plan_id
+
+    def __str__(self):
+        return self.__unicode__()
 
 
 class StripeSubscription(models.Model, mixins.StripeMixin, mixins.StripeSubscriptionMixin):


### PR DESCRIPTION
Casting an object to unicode is deprecated in Python3, and instead we'll cast to a string which calls the __str__ method. In order to preserve older functionality these methods just call the __unicode__ method that's already defined.